### PR TITLE
Change s2_cell_id to uint64 in ClientWeather.proto

### DIFF
--- a/src/POGOProtos/Map/Weather/ClientWeather.proto
+++ b/src/POGOProtos/Map/Weather/ClientWeather.proto
@@ -6,7 +6,7 @@ import "POGOProtos/Map/Weather/GameplayWeather.proto";
 import "POGOProtos/Map/Weather/WeatherAlert.proto";
 
 message ClientWeather {
-	int64 s2_cell_id = 1;
+	uint64 s2_cell_id = 1;
 	.POGOProtos.Map.Weather.DisplayWeather display_weather = 2;
 	.POGOProtos.Map.Weather.GameplayWeather gameplay_weather = 3;
 	repeated .POGOProtos.Map.Weather.WeatherAlert alerts = 4;


### PR DESCRIPTION
s2_cell_id should be uint64 to avoid overflowing like in POGOProtos/Map/MapCell.proto