### PR TITLE
Missing Weather Fields

### DIFF
--- a/base/base.proto
+++ b/base/base.proto
@@ -8010,6 +8010,7 @@ message GameplayWeatherProto {
 		FOG = 7;
 	}
 
+	WeatherCondition gameplay_condition = 1;
 }
 
 message GenerateCombatChallengeIdOutProto {
@@ -17979,6 +17980,7 @@ message WeatherAlertProto {
 		EXTREME = 2;
 	}
 
+	Severity severity = 1;
 	bool warn_weather = 2;
 }
 

--- a/base/raw_protos.proto
+++ b/base/raw_protos.proto
@@ -19706,6 +19706,7 @@ message GameplayWeatherProto {
 		SNOW = 6;
 		FOG = 7;
 	}
+	WeatherCondition gameplay_condition = 1;
 }
 
 // ref: Niantic.Rpc.WeatherAlertProto
@@ -19717,6 +19718,7 @@ message WeatherAlertProto {
 		EXTREME = 2;
 	}
 
+	Severity severity = 1;
 	bool warn_weather = 2;
 }
 

--- a/base/v0.191.2.proto
+++ b/base/v0.191.2.proto
@@ -8009,7 +8009,7 @@ message GameplayWeatherProto {
 		SNOW = 6;
 		FOG = 7;
 	}
-
+	WeatherCondition gameplay_condition = 1;
 }
 
 message GenerateCombatChallengeIdOutProto {
@@ -17979,6 +17979,7 @@ message WeatherAlertProto {
 		EXTREME = 2;
 	}
 
+	Severity severity = 1;
 	bool warn_weather = 2;
 }
 


### PR DESCRIPTION
These two fields were in the src folder protos but missing in the single proto. I built the language protos with these and they linked to the enums correctly. Is there something in the script that needs to be changed or they aren't in the proto dump anymore?